### PR TITLE
Improve performance by removing streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,13 @@ class Storage {
         response.arrayBuffer().then((arrayBuffer) => {
           const buf = Buffer.from(arrayBuffer)
           if (!opts) return cb(null, buf)
+
           const offset = opts.offset || 0
-          const len = opts.length || buf.length - offset
+          const len = opts.length || (buf.length - offset)
+
+          if (opts.offset === 0 && len === buf.length - offset) {
+            return cb(null, buf)
+          }
           return cb(null, buf.slice(offset, len + offset))
         }, cb)
       })

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class Storage {
           const offset = opts.offset || 0
           const len = opts.length || buf.length - offset
           return cb(null, buf.slice(offset, len + offset))
-        }).catch(cb)
+        }, cb)
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class Storage {
           const offset = opts.offset || 0
           const len = opts.length || (buf.length - offset)
 
-          if (opts.offset === 0 && len === buf.length - offset) {
+          if (offset === 0 && len === buf.length) {
             return cb(null, buf)
           }
           return cb(null, buf.slice(offset, len + offset))

--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ class Storage {
       return nextTick(cb, new Error('Chunk length must be ' + this.chunkLength))
     }
 
-    const response = new window.Response(buf, {
+    // Even though new Response() can take buf directly, creating a Blob first
+    // is significantly faster in Chrome and Firefox
+    const blob = new window.Blob([buf])
+
+    const response = new window.Response(blob, {
       status: 200,
       headers: {
         'Content-Type': 'application/octet-stream',


### PR DESCRIPTION
`Response` can be created directly from `TypedArray` and `Blob` objects, and can generate `ArrayBuffer` as output using `Response.arrayBuffer()`.

From a quick glance I think these interfaces are available in at least as many browsers as the original streams-based interfaces.

I did some testing in Chrome, Firefox, and Safari and the combination of using `Blob` in `put()` and `response.arrayBuffer()` in `get()` gives better overall performance than the alternatives. I have no idea why passing a `Blob` rather than a `Uint8Array` into `new Response()` is faster, but it is consistently so in Firefox and Chrome.

The only case this is slightly slower is in Chrome, where `put()` is slightly faster (perhaps around 10%) using `ReadableStream` than `Blob` or `Uint8Array`. I'm not sure why.

Did I miss some other reason you used `ReadableStream` originally?