### PR TITLE
Don't reopen cache on every operation, and improve destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,15 +100,9 @@ class Storage {
     this.closed = true
     this.cachePromise = null
 
-    window.caches.open(this.name).then((cache) => {
-      cache.keys().then((keys) => {
-        keys.forEach((request) => {
-          cache.delete(request)
-        })
-
-        cb(null)
-      })
-    })
+    window.caches.delete(this.name).then(() => {
+      cb(null)
+    }, cb)
   }
 }
 


### PR DESCRIPTION
Two changes:
1. Don't reopen the cache on every get/put operation. This improves performance significantly in Firefox, and has no performance effect in Chrome and Safari
2. Delete the entire cache in `destroy`
